### PR TITLE
Improve typo + commit checking + CI re-usability

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+PR_TYPOS="ec-oh | ro-el | fi-x.?me"
+BR_TYPOS="fi-x.?up! | squa-sh! | do.*not.*me-rge"
+
+# Add ansible.cfg to pick up roles path.
+echo -e '[defaults]\nroles_path = ../' > ansible.cfg
+
+# Galaxy would normally install this with a "cevich." prefix
+# which is missing from github repo name
+ROLENAME="$(basename $PWD)"
+echo "$ROLENAME" | grep -q 'cevich' || ln -sfv "$ROLENAME" "../cevich.$ROLENAME"
+
+TYPOS="${PR_TYPOS}"
+if [ "${TRAVIS_BRANCH:-master}" == "master" ]
+then
+    TYPOS="${PR_TYPOS} | ${BR_TYPOS}"
+    ANCESTOR=$(git merge-base origin/master HEAD)
+else
+    ANCESTOR=$(git merge-base origin/$TRAVIS_BRANCH HEAD)
+fi
+TYPOS=$(echo "$TYPOS" | tr -d ' -')
+
+[ $ANCESTOR != $(git rev-parse HEAD) ] || ANCESTOR="HEAD^"
+
+echo "Checking against ${ANCESTOR} for conflict and whitespace problems:"
+git diff --check ${ANCESTOR}..HEAD  # Silent unless problem detected
+
+git log -p ${ANCESTOR}..HEAD -- . ':!.travis.yml' &> /tmp/commits_with_diffs
+LINES=$(wc -l </tmp/commits_with_diffs)
+if (( $LINES == 0 ))
+then
+    echo "FATAL: no changes found since ${ANCESTOR}"
+    exit 3
+fi
+
+echo "Examining $LINES change lines for typos:"
+set +e
+egrep -a -i -2 --color=always "$TYPOS" /tmp/commits_with_diffs && exit 3
+
+source ./.travis_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 ---
+
 language: python
 branch:
     only:
@@ -12,39 +13,12 @@ matrix:
 git:
     submodules: false
 
-env:
-    global:
-        - TYPOS="'ecoh' 'roel' 'fixup!' 'squash!' 'FIXME' '<<<<<<<' '=======' '>>>>>>>'"
-        # fix vim syntax highlighting: "
-
 before_install:
   - sudo apt-get update -qq
-  - pip install ansible==2.3
-
-install:
-  # Add ansible.cfg to pick up roles path.
-  - echo -e '[defaults]\nroles_path = ../' > ansible.cfg
-  # Galaxy would normally install this with a cevich prefix
-  - export ROLEBASE="$(basename $PWD)" && ln -sfv "$ROLEBASE" "../cevich.$ROLEBASE"
+  - pip install ansible==2.4
 
 script:
-  - >
-        echo "$(git log -1 --format=%H origin/master)" > /tmp/start;
-        echo "$(git log -1 --format=%H HEAD)" > /tmp/end;
-        git log -p $(cat /tmp/start)..$(cat /tmp/end) -- . ':!.travis.yml' &> /tmp/commits;
-        echo "Typos found:";
-        egrep -a -i -2 "$TYPOS" /tmp/commits | tee /tmp/typos;
-        test "$(cat /tmp/typos | wc -l)" -eq "0" || exit 1;
-  - stat /tmp/foobar || true
-  - ansible-playbook -i tests/inventory tests/test.yml --verbose --syntax-check
-  - stat /tmp/foobar || true
-  - ansible-playbook -i tests/inventory tests/test.yml --verbose
-  - >
-        ansible-playbook -i tests/inventory tests/again.yml --verbose | tee /tmp/idempotence;
-        grep -q 'changed=0.*failed=0' /tmp/idempotence \
-            && (echo 'Idempotence test: pass' && exit 0) \
-            || (echo 'Idempotence test: fail' && exit 1);
-  - stat /tmp/foobar || true
+  - ./.travis.sh
 
 notifications:
     webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis_test.sh
+++ b/.travis_test.sh
@@ -1,0 +1,23 @@
+
+set -e
+
+no_foo() {
+    echo "Verifying test marker file absence"
+    stat /tmp/foobar || true
+}
+
+echo "Testing role syntax"
+no_foo
+ansible-playbook -i tests/inventory tests/test.yml --verbose --syntax-check
+
+echo "Testing role functionality"
+no_foo
+ansible-playbook -i tests/inventory tests/test.yml
+
+echo "Testing role idempotence"
+no_foo
+ansible-playbook -i tests/inventory tests/again.yml \
+    | grep -q 'changed=0.*failed=0' \
+            && (echo 'Idempotence test: pass' && exit 0) \
+            || (echo 'Idempotence test: fail' && exit 1)
+no_foo


### PR DESCRIPTION
* Improve git commit and typo checking to better handle development
forks.
* Split repo-specific tests into their own include file so
Travis CI setup and git/typo checks can be re-used in other galaxy roles.

Signed-off-by: Chris Evich <cevich@redhat.com>