### PR TITLE
Fix missing hostvars.localhost.ansible_machine_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Role Variables
 > touchstone state. When `True`, it indicates the stone was touched at
 > least once in the past.
 
+`touchstone_control_host`:
+> Optional, defaults to ``localhost``.  When touching a touchstone, details
+> from this inventory host will be used for the ``touchstone_filepath`` content.
+
+
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,6 @@ stone_name: "{{ playbook_dir | basename }}"
 
 # Full/absolute path where touchstone lives, must be permanent and readable/writable.
 touchstone_filepath: '{{ ansible_user_dir | default("/var/tmp") }}'
+
+# Ansible inventory name of the control-host for stone initialization
+touchstone_control_host: localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,10 +4,17 @@
   set_fact:
     stone_touched: False
 
+- name: Setup is run against the touchstone_control_host
+  setup:
+    gather_subset: network
+  when: 'touchstone_control_host not in hostvars | list'
+
 - name: Input expectations are verified
   assert:
     that:
-      - 'hostvars.localhost.ansible_machine_id | default("", True) | trim | length'
+      - 'touchstone_control_host | default("", True) | trim | length'
+      - 'touchstone_control_host in hostvars | list'
+      - 'hostvars[touchstone_control_host].ansible_machine_id | default("", True) | trim | length'
       - 'stone_touched == False'  # make sure it's not read-only
       - 'touchstone_filepath | default("", True) | trim | length'
       - 'touch_touchstone | default(False) in [True, False]'
@@ -31,9 +38,9 @@
     result: '{{ result }} {{ item | quote }}'
   when: touch_touchstone | default(False)
   with_items:
-    - 'Touched by {{ hostvars.localhost.ansible_nodename }}'
-    - 'Machine_id {{ hostvars.localhost.ansible_machine_id }}'
-    - 'On {{ hostvars.localhost.ansible_date_time.iso8601 }}'
+    - 'Touched by {{ hostvars[touchstone_control_host].ansible_nodename }}'
+    - 'Machine_id {{ hostvars[touchstone_control_host].ansible_machine_id }}'
+    - 'On {{ hostvars[touchstone_control_host].ansible_date_time.iso8601 }}'
 
 - name: Tasks are only run outside of --check mode
   block:


### PR DESCRIPTION
When touching a new touchstone, it's contents are set based on details
obtained from the control_host (executing Ansible).  In some situations
the inventory name of this host may not be 'localhost'.  When this
occurs, the play will fail.

Fix this by adding a variable, defaulting to 'localhost', and ensure
it's facts are gathered prior to reference.  Update the README with
details about this variable and it's purpose.

Signed-off-by: Chris Evich <cevich@redhat.com>