### PR TITLE
Debug target stone path instead of result

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,9 @@
 - name: Tasks are only run outside of --check mode
   block:
 
+    - name: The touchstone file path on target is debugged
+      debug: msg='{{ touchstone_filepath }}/.{{ stone_name }}.touchstone'
+
     - name: Touchstone script is executed to modify and/or retrieve stone status
       script: >
         touchstone.py \
@@ -39,9 +42,6 @@
                     result.stdout_lines[0] | trim | bool and
                     result.stdout_lines | length == 1
       register: result
-
-    - name: The script's result is debugged
-      debug: var='result'
 
     - name: The stone is/was touched, set stone_touched fact True
       set_fact:


### PR DESCRIPTION
If there's any failure, it's critical to have this detail for debugging.
Whereas the contents of the result variable are almost always useless.

Signed-off-by: Chris Evich <cevich@redhat.com>