### PR TITLE
Don't require touchstone_control_host

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Role Variables
 > touchstone state. When `True`, it indicates the stone was touched at
 > least once in the past.
 
-`touchstone_control_host`:
-> Optional, defaults to ``localhost``.  When touching a touchstone, details
-> from this inventory host will be used for the ``touchstone_filepath`` content.
-
+`touchstone_template`:
+>
+> Optional, full path to jinja2 template used for generating the touchstone
+> file contents.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,5 +9,5 @@ stone_name: "touchstone"
 # Full/absolute path where touchstone lives, must be permanent and readable/writable.
 touchstone_filepath: '{{ ansible_user_dir | default("/var/tmp") }}'
 
-# Ansible inventory name of the control-host for stone initialization
-touchstone_control_host: localhost
+# Absolute path to template used for rendering touchstone file contents
+touchstone_template: "{{ role_path }}/templates/touchstone.j2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,39 +1,28 @@
 ---
 
-- name: stone_touched fact is initially false and template path is buffered
-  set_fact:
-    stone_touched: False
-    result: "{{ role_path }}/templates/touchstone.j2"
-
-- name: Setup is run against the touchstone_control_host
-  setup:
-    gather_subset: network
-  when: touchstone_control_host not in hostvars | list or
-        hostvars[touchstone_control_host].ansible_machine_id is undefined
-
 - name: Input expectations are verified
   assert:
     that:
-      - 'touchstone_control_host | default("", True) | trim | length'
-      - 'hostvars[touchstone_control_host].ansible_machine_id | default("", True) | trim | length'
-      - 'stone_touched == False'  # make sure it's not read-only
       - 'touchstone_filepath | default("", True) | trim | length'
       - 'touch_touchstone | default(False) | bool in [True, False]'
-      - 'result | is_file'
-      - 'role_path ~ "/templates/touchstone.j2" | is_file'
+      - 'touchstone_template | is_file'
 
-- name: Tasks are only run outside of --check mode
+- name: The touchstone file path on target is debugged
+  debug: msg='{{ touchstone_filepath }}/.{{ stone_name }}.touchstone'
+
+- name: The stone was not touched, unless prooven otherwise.
+  set_fact:
+    stone_touched: false
+
+- name: Script tasks only run outside of --check mode
   block:
 
-    - name: The touchstone file path on target is debugged
-      debug: msg='{{ touchstone_filepath }}/.{{ stone_name }}.touchstone'
-
-    - name: Touchstone script is executed to modify and/or retrieve stone status
+    - name: Touchstone script is executed to set and/or retrieve stone status
       script: >
         touchstone.py \
         {{ "--touch" if touch_touchstone | bool else "" }} \
         {{ touchstone_filepath }}/.{{ stone_name }}.touchstone \
-        {% for line in lookup("template", result).splitlines() %} \
+        {% for line in lookup("template", touchstone_template).splitlines() %} \
             {{ line | quote }} \
         {% endfor %}
       # N/B: The script module combines stderr/stdout from the script

--- a/templates/touchstone.j2
+++ b/templates/touchstone.j2
@@ -1,3 +1,1 @@
-Touched by {{ hostvars[touchstone_control_host].ansible_nodename }}
-Machine_id {{ hostvars[touchstone_control_host].ansible_machine_id }}
-On {{ hostvars[touchstone_control_host].ansible_date_time.iso8601 }}
+Touched by {{ lookup("pipe","uname -a") }}


### PR DESCRIPTION
Simply put the content-generating commands directly into the template.
This ensures they always execute on the control host and never need to
be validated by task-assertions.  If different content is required,
simply point to a different template.

Signed-off-by: Chris Evich <cevich@redhat.com>